### PR TITLE
feat: 공통 TabLayout 추가

### DIFF
--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -77,7 +77,7 @@ const Wrapper = styled.nav`
   flex-shrink: 0;
 
   width: 100%;
-  height: 80px; // 하단 네비게이션 바 높이
+  height: 85px; // 하단 네비게이션 바 높이
 
   background-color: ${(props) => props.theme.colors.navBackground};
   box-shadow: ${(props) => props.theme.shadows.on};

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -36,7 +36,7 @@ const LayoutContainer = styled.div`
     height: 100vh;
   }
 
-  @media (max-height: 844px) {
+  @media (max-height: 850px) {
     //width: 100vw;
     height: 100vh;
   }

--- a/src/components/layout/TabLayout.tsx
+++ b/src/components/layout/TabLayout.tsx
@@ -1,0 +1,132 @@
+import useWindowWidthResize from '@hooks/useWindowWidthResize';
+import { flexCenter } from '@styles/CommonStyles';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+type TabProps = {
+  id: string;
+  label: string;
+  content: React.ReactNode; // 탭의 내용을 React 노드로 정의
+};
+
+type TabsProps = {
+  tabs: TabProps[];
+  selectedTab: string;
+  onTabSelect: (tabId: string) => void;
+  tabHeaderColor?: string;
+  activeTabHeaderColor?: string;
+  indicatorColor?: string;
+  indicatorRailColor?: string;
+};
+
+const TabLayout = ({
+  tabs,
+  selectedTab,
+  onTabSelect,
+  tabHeaderColor = '#9F9F9F',
+  activeTabHeaderColor = '#575755',
+  indicatorColor = '#575755',
+  indicatorRailColor = '#DDDDDD',
+}: TabsProps) => {
+  const tabRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
+  const [indicatorWidth, setIndicatorWidth] = useState<number>(0);
+  const [indicatorOffset, setIndicatorOffset] = useState<number>(0);
+
+  const handleResize = useCallback(() => {
+    const tab = tabRefs.current[selectedTab];
+    if (tab && tab.parentNode && tab.parentNode instanceof HTMLElement) {
+      const extraWidth = 70; // 추가 너비
+      const rect = tab.getBoundingClientRect(); // 탭의 위치와 크기를 정확히 계산
+      const parentRect = tab.parentNode.getBoundingClientRect(); // 부모 요소의 위치와 크기 계산
+      const newWidth = rect.width + extraWidth;
+      const newOffset = rect.left - parentRect.left - extraWidth / 2; // 부모 요소 기준으로 상대적 위치 계산
+      setIndicatorWidth(newWidth);
+      setIndicatorOffset(newOffset);
+    }
+  }, [selectedTab]);
+
+  useEffect(() => {
+    handleResize();
+  }, [selectedTab, tabs, handleResize]);
+  // 윈도우 리사이즈 시에도, 탭 인디게이터가 따라다니도록 호출
+  useWindowWidthResize(handleResize);
+
+  return (
+    <TabsContainer>
+      <TabHeaders>
+        {tabs.map((tab) => (
+          <TabHeader
+            key={tab.id}
+            onClick={() => onTabSelect(tab.id)}
+            ref={(el) => (tabRefs.current[tab.id] = el)}
+            isactive={(selectedTab === tab.id).toString()}
+            activecolor={activeTabHeaderColor}
+            color={tabHeaderColor}>
+            {tab.label}
+          </TabHeader>
+        ))}
+      </TabHeaders>
+      <TabIndicatorRail color={indicatorRailColor} />
+      <TabIndicator width={indicatorWidth} offset={indicatorOffset} color={indicatorColor} />
+      {tabs.map((tab) => selectedTab === tab.id && <TabPanel key={tab.id}>{tab.content}</TabPanel>)}
+    </TabsContainer>
+  );
+};
+
+export default TabLayout;
+
+const TabsContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const TabHeaders = styled.div`
+  display: flex;
+  justify-content: space-around;
+  width: 100%;
+`;
+
+const TabHeader = styled.div<{
+  isactive: string;
+  activecolor: string;
+  color: string;
+}>`
+  ${flexCenter}
+  position: relative;
+  cursor: pointer;
+  padding: 0 20px 0 20px;
+  font-size: 16px;
+  height: 30px;
+  color: ${(props) => (props.isactive === 'true' ? props.activecolor : props.color)};
+  font-weight: ${(props) => (props.isactive === 'true' ? 700 : 400)};
+`;
+
+const TabIndicatorRail = styled.div<{ color: string }>`
+  position: absolute;
+  width: 100%;
+  height: 4px;
+  background-color: ${(props) => props.color};
+`;
+
+const TabIndicator = styled.div<{
+  width: number;
+  offset: number;
+  color: string;
+}>`
+  height: 4px;
+  border-radius: 6px;
+  background-color: ${(props) => props.color};
+  position: absolute;
+  left: ${(props) => props.offset}px;
+  width: ${(props) => props.width}px;
+  transition:
+    left 0.3s ease,
+    width 0.3s ease;
+`;
+
+const TabPanel = styled.div`
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+`;

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -2,9 +2,11 @@ import styled from 'styled-components';
 import TopNavigation from '@layout/TopNavigation';
 import BottomNavigation from '@layout/BottomNavigation';
 
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import useMonthNavigator from '@hooks/useMonthNavigator';
+import TabLayout from '@components/layout/TabLayout';
 import MonthNavigatorBtn from '@components/date/MonthNavigatorBtn';
 
 type DashboardNavProps = {
@@ -62,10 +64,27 @@ const MonthNavWrapper = styled.div`
 
 const DashboardPage = () => {
   const monthNav = useMonthNavigator(); // monthNav.currentDate = 현재 선택된 월
-
+  const [selectedTab, setSelectedTab] = useState<string>('TAB_SPEND'); // 지출 탭 기본 선택
+  const handleTabSelect = (tabId: string) => {
+    setSelectedTab(tabId);
+  };
+  const tabData = [
+    {
+      id: 'TAB_SPEND',
+      label: '지출',
+      content: <Content>Content for Tab 1</Content>,
+    },
+    {
+      id: 'TAB_SAVE',
+      label: '절약',
+      content: <Content>Content for Tab 2</Content>,
+    },
+  ];
   return (
     <NavigationLayout {...monthNav}>
-      <DashboardContainer>대시보드</DashboardContainer>
+      <DashboardContainer>
+        <TabLayout tabs={tabData} selectedTab={selectedTab} onTabSelect={handleTabSelect} />
+      </DashboardContainer>
     </NavigationLayout>
   );
 };
@@ -75,4 +94,15 @@ export default DashboardPage;
 const DashboardContainer = styled.div`
   width: 100%;
   height: 100%;
+  overflow: hidden;
+  margin-top: 10px;
+  padding: 0 15px 0 15px;
+`;
+
+const Content = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  /* height: 1000px; */
+  padding-top: 4px; // indigator 영역만큼 padding 주기
 `;

--- a/src/pages/expenseDetailView/ExpenseDetailViewPage.tsx
+++ b/src/pages/expenseDetailView/ExpenseDetailViewPage.tsx
@@ -178,6 +178,7 @@ const ExpenseDetailViewPage = () => {
     error: errorExpenseData,
   } = useQuery(['expense', id], () => fetchExpenseById(id), {
     enabled: !!id, // id가 있을 때만 쿼리 실행
+    refetchOnWindowFocus: false, // 윈도우 포커스 시, 자동 새로고침 방지
   });
 
   const saveMutation = useMutation({
@@ -207,7 +208,7 @@ const ExpenseDetailViewPage = () => {
   const commentMutation = useMutation(fetchAIComment, {
     onSuccess: (commentData) => {
       console.log(commentData.data.aiComment);
-      // #20240516.syjang, aiComment->co
+      // #20240516.syjang, aiComment->content로 변경
       methods.setValue('aiComment', commentData.data.content);
     },
     onError: (error) => {

--- a/src/pages/main/components/Calendar.tsx
+++ b/src/pages/main/components/Calendar.tsx
@@ -46,6 +46,10 @@ const Calendar = ({ currentDate, setCurrentDate, data }: CalendarProps) => {
     if (todayData) {
       setDaySpend(todayData.daySpend);
       setDaySave(todayData.daySave);
+    } else {
+      // 데이터가 없는 경우, 라벨 0으로 초기화
+      setDaySpend(0);
+      setDaySave(0);
     }
   }, [currentDate, data]);
 

--- a/src/pages/statistics/StatisticsPage.tsx
+++ b/src/pages/statistics/StatisticsPage.tsx
@@ -1,8 +1,11 @@
-import BottomNavigation from '@layout/BottomNavigation';
-import TopNavigation from '@layout/TopNavigation';
 import styled from 'styled-components';
+import TopNavigation from '@layout/TopNavigation';
+import BottomNavigation from '@layout/BottomNavigation';
 
 import { useNavigate } from 'react-router-dom';
+
+import TabLayout from '@components/layout/TabLayout';
+import { useState } from 'react';
 
 type NavLayoutProps = {
   children: React.ReactNode;
@@ -15,6 +18,9 @@ const NavigationLayout = ({ children }: NavLayoutProps) => {
       <TopNavigation
         _TopBar={
           <TopNavigation.TopBar
+            centerContent={
+              <TopNavigation.TopBar.CenterTitle>둘러보기</TopNavigation.TopBar.CenterTitle>
+            }
             rightContent={
               <TopNavigation.TopBar.SettingGrayButton
                 onClick={() => {
@@ -31,9 +37,36 @@ const NavigationLayout = ({ children }: NavLayoutProps) => {
 };
 
 const StatisticsPage = () => {
+  const [selectedTab, setSelectedTab] = useState<string>('TAB_MBTI'); // 지출 탭 기본 선택
+  const handleTabSelect = (tabId: string) => {
+    setSelectedTab(tabId);
+  };
+
+  // content에 탭 컴포넌트 넣기
+  const tabData = [
+    {
+      id: 'TAB_MBTI',
+      label: 'MBTI별',
+      content: <Content>엠비티아이이</Content>,
+    },
+    {
+      id: 'TAB_GENDER',
+      label: '성별',
+      content: <Content>성별</Content>,
+    },
+  ];
   return (
     <NavigationLayout>
-      <StatisticsContainer>둘러보기(통계)</StatisticsContainer>
+      <StatisticsContainer>
+        <TabLayout
+          tabs={tabData}
+          selectedTab={selectedTab}
+          onTabSelect={handleTabSelect}
+          tabHeaderColor="#9F9F9F" // 탭 헤더 글씨 색
+          activeTabHeaderColor="#575755" // 선택된 탭 헤더 글씨 색
+          indicatorColor="#575755" // 선택된 탭 인디게이터 색 (indicatorRailColor 넘기면 인디게이터 레일 색도 지정 가능)
+        />
+      </StatisticsContainer>
     </NavigationLayout>
   );
 };
@@ -44,6 +77,16 @@ const StatisticsContainer = styled.div`
   background-color: transparent;
   width: 100%;
   height: 100%;
+  overflow: hidden;
+  margin-top: 10px;
+  padding: 0 15px 0 15px;
+`;
 
-  overflow: auto;
+// #20240517.syjang, 예시 Content 입니다.
+const Content = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 1000px; // 스크롤 생기는것 확인하시라고 예시로 1000px 넣어뒀습니다.
+  padding-top: 4px; // indigator 영역만큼 padding 주기 ( 패딩 더 추가하시려면, 4px 더해서 계산하면 됩니다. )
 `;


### PR DESCRIPTION
## 🧰 변경 타입

- [x] 🤹 FEAT : 기능 추가
- [ ] 🔧 FIX : 버그 수정
- [ ] ♻️ 리팩토링 (no functional changes, no api changes)
- [ ] 🎨 DESIGN : 디자인 작업
- [ ] 🚚 BUILD : 빌드 관련 변경
- [ ] 🤖 STYLE : 코드 스타일 혹은 포맷 관련 변경
- [ ] 💬 COMMENT : 주석 작성
- [ ] 📄 DOCS : 문서 작업
- [ ] 🗑️ DELETE : 파일 삭제
- [ ] 🩹 CHORE : 그 외 자잘한 수정

## 📦 요약

![image](https://github.com/SpinLog/frontend/assets/137787915/cf01bc39-510b-4866-a295-ddc2ccc1ba99)

- 재사용 가능한 탭 컴포넌트 추가 (둘러보기에도 예시로 넣어놨습니다.)

## ✒️ 변경 상세 내용

### 탭 컴포넌트

- 헤더 색, 헤더 강조 색, 헤더 인디게이터와 헤더 인디게이터 레일의 색 지정 가능
- tabData 생성해서 content에 자식 컴포넌트 넘기시면 됩니다.

### 자잘한 수정
- 하단 네비게이션 바 높이 조절
- @media 850px 으로 높이 제한 변경(850px 보다 작아지면 높이가 화면 전체를 채움) : 모바일에서 꽉 차게 하려고 변경했습니다.

---

## 🔗 Reference

- 해당 테스크를 수행하며 참고한 Link를 모두 작성 (Reference)
