### PR TITLE
Feature/fix page message

### DIFF
--- a/src/api/post/index.ts
+++ b/src/api/post/index.ts
@@ -3,7 +3,7 @@ import { ExpenseFormType } from '@models/expense';
 import type { UserFormType } from '@models/user';
 
 /**
- * 입력 페이지 저장 쿼리메인 페이지 데이터 (예산, 달력, 요약 정보)
+ * 입력 페이지 저장 쿼리
  * @param expenseData 게시글 데이터 (ExpenseFormType)
  * @returns
  */

--- a/src/assets/images/icon/checkIcon.svg
+++ b/src/assets/images/icon/checkIcon.svg
@@ -1,0 +1,3 @@
+<svg width="9" height="6" viewBox="0 0 9 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.29001 0.970214L3.35251 4.90771L1.31226 2.78953" stroke="white" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/date/MonthNavigatorBtn.tsx
+++ b/src/components/date/MonthNavigatorBtn.tsx
@@ -40,7 +40,7 @@ const Wrapper = styled.div<{ color: string }>`
   ${flexBetween}
   font-size: 16px;
   font-weight: 600;
-  width: 235px;
+  width: 240px;
 
   color: ${(props) => props.color};
 `;

--- a/src/components/emotion/index.tsx
+++ b/src/components/emotion/index.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
-import { borderCheck, flexCenter, flexColumnCenter } from '@styles/CommonStyles';
+import { flexCenter, flexColumnCenter } from '@styles/CommonStyles';
 
+import CheckIcon from '@assets/images/icon/checkIcon.svg?react';
 import type { EmotionKey } from '@models/index';
 import { getEmotionIcon, getEmotionText } from '@models/emotion';
 
@@ -25,9 +26,9 @@ const Emotion = ({
     <EmotionWrapper>
       <EmotionIcon onClick={onClick} size={`${iconSize}px`}>
         <EmotionSVG />
+        {isSelect && <SelectMark size={`${selectSize}px`} />}
       </EmotionIcon>
       <EmotionText size={`${textSize}px`}>{getEmotionText(emotionKey)}</EmotionText>
-      {isSelect && <SelectMark size={`${selectSize}px`} />}
     </EmotionWrapper>
   );
 };
@@ -39,11 +40,11 @@ const EmotionWrapper = styled.div`
   margin-bottom: 5px;
   cursor: pointer;
   width: 90px;
-  position: relative;
 `;
 
 const EmotionIcon = styled.div<{ size: string }>`
   ${flexCenter}
+  position: relative;
   width: ${(props) => props.size};
   height: ${(props) => props.size};
   border-radius: 50%;
@@ -58,21 +59,15 @@ const EmotionText = styled.div<{ size: string }>`
   white-space: nowrap;
 `;
 
-const SelectMark = styled.div<{ size: string }>`
+const SelectMark = styled(CheckIcon)<{ size: string }>`
   position: absolute;
+  top: 0;
+  right: 0;
+
   width: ${(props) => props.size};
   height: ${(props) => props.size};
   background-color: #333331;
   border-radius: 50%;
 
-  top: 0;
-  right: 0;
-  transform: translateY(-25%);
-
-  &::after {
-    ${borderCheck}
-    width: 4px;
-    height: 9px;
-    border-color: #ffffff;
-  }
+  padding: 3px;
 `;

--- a/src/components/expense/SatisfactionRange.tsx
+++ b/src/components/expense/SatisfactionRange.tsx
@@ -11,16 +11,10 @@ import { getEmotionIcon } from '@models/emotion';
 type SatisfactionRangeProps = {
   emotion: EmotionKey;
   satisfaction: number;
-  // setSatisfaction?: (state: number) => void; // isEdit이 true인 경우 같이 넘겨줘야함.
   isEdit?: boolean;
 };
 
-const SatisfactionRange = ({
-  emotion,
-  satisfaction,
-  isEdit = false,
-  // setSatisfaction,
-}: SatisfactionRangeProps) => {
+const SatisfactionRange = ({ emotion, satisfaction, isEdit = false }: SatisfactionRangeProps) => {
   const max = 5;
   const min = 1;
 
@@ -28,24 +22,11 @@ const SatisfactionRange = ({
   const thumb = 16;
   const height = 10;
   const [rangeWidth, setRangeWidth] = useState<number>(212);
-  // const [value, setValue] = useState<number>(satisfaction); // props로 넘겨받게될듯
   const value: number = satisfaction;
   const rangeRef = useRef<HTMLDivElement>(null);
 
   const EmotionSVG = getEmotionIcon(emotion);
 
-  // const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-  //   if (isEdit && setSatisfaction && event.target) {
-  //     setSatisfaction(parseInt(event.target.value));
-  //   }
-  //   setValue(parseInt(event.target?.value));
-  // };
-  // const handleClick = (satisfaction: number) => {
-  //   if (isEdit && setSatisfaction) {
-  //     setSatisfaction(satisfaction);
-  //   }
-  //   setValue(satisfaction);
-  // };
   const getNomalized = (val: number): number => (val - min) / (max - min);
   const calculateLeft = (val: number) => {
     return getNomalized(val) * (rangeWidth - thumb) + thumb / 2;
@@ -80,19 +61,13 @@ const SatisfactionRange = ({
             min={min}
             max={max}
             step={0.1}
-            // onChange={handleChange}
             height={height}
             thumb={thumb}
             disabled={!isEdit}
           />
           <RangeButtonContainer>
-            {[1, 2, 3, 4, 5].map((x, i) => (
-              <RangeButton
-                key={i}
-                // onClick={() => {handleClick(x);}}
-              >
-                {x}
-              </RangeButton>
+            {[1, 2, 3, 4, 5].map((score, i) => (
+              <RangeButton key={i}>{score}</RangeButton>
             ))}
           </RangeButtonContainer>
         </RangeSection>

--- a/src/models/emotion/index.ts
+++ b/src/models/emotion/index.ts
@@ -37,7 +37,7 @@ export const Emotions: Readonly<EmotionMap> = Object.freeze({
   TIRED: { text: '피곤/지침', color: '#111F68', icon: getStyledComponent(Tired) },
   DEPRESSED: { text: '우울/권태', color: '#867BF4', icon: getStyledComponent(Depressed) },
   SAD: { text: '슬픔/절망', color: '#2E4FFF', icon: getStyledComponent(Sad) },
-  SHY: { text: '부끄러움/민망', color: '#FFB49C', icon: getStyledComponent(Shy) },
+  SHY: { text: '민망/수치', color: '#FFB49C', icon: getStyledComponent(Shy) },
   SORRY: { text: '죄책감/미안함', color: '#333331', icon: getStyledComponent(Sorry) },
   EXCITED: { text: '기분좋은/신나는', color: '#FFC700', icon: getStyledComponent(Excited) },
   FLUTTER: { text: '설렘/기대', color: '#FF84AA', icon: getStyledComponent(Flutter) },

--- a/src/models/expense/index.ts
+++ b/src/models/expense/index.ts
@@ -6,14 +6,14 @@ export type ExpenseSummaryType = {
   emotion: EmotionKey;
   satisfaction: number;
   content: string;
-  amount: number;
+  amount: string;
   registerType: Register;
 };
 
 // 입력, 조회, 수정 폼 + 상세 조회 타입
 export type ExpenseFormType = {
   content: string; // 소비 내용 (원래 물건)
-  amount: number; // 금액 (절약 또는 지출한)
+  amount: string; // 금액 (절약 또는 지출한)
   spendDate: string; // 소비 날짜, 시간 (저장 시간 아님) -> 내가 서버에 보낼 땐 string 타입으로? Date로?
   event: string; // 사건
   thought: string; // 생각

--- a/src/models/user/index.ts
+++ b/src/models/user/index.ts
@@ -2,7 +2,7 @@ import { EI, Gender, NS, PJ, TF } from '..';
 
 // 환경설정(내정보)에서의 사용자 정보 form 타입
 export type UserFormType = {
-  budget: number;
+  budget: string; // #,##0 형식 표기
   gender: Gender;
   EI: EI;
   NS: NS;

--- a/src/pages/addExpense/AddExpensePage.tsx
+++ b/src/pages/addExpense/AddExpensePage.tsx
@@ -63,6 +63,7 @@ const AddExpensePage = () => {
     criteriaMode: 'all',
     defaultValues: {
       registerType: 'SPEND', // 소비, 절약
+      amount: '', // 금액, #,##0 형태
       content: '', // 소비 내용 (원래 물건)
       spendDate: '', // 소비 날짜, 시간 (저장 시간 아님) -> 추가 필요 필드
       event: '', // 사건
@@ -113,7 +114,9 @@ const AddExpensePage = () => {
 
   // 제출
   const handleSubmit = (data: ExpenseFormType) => {
-    expenseMutation.mutate(data);
+    // amount: #,##0  => 다시 숫자만 남은 형태로 변경 필요
+    const numberAmount = data.amount.replace(/,/g, '');
+    expenseMutation.mutate({ ...data, amount: numberAmount });
   };
 
   return (

--- a/src/pages/addExpense/components/WriteExpense.tsx
+++ b/src/pages/addExpense/components/WriteExpense.tsx
@@ -9,13 +9,14 @@ import {
   textArea,
   textAreaWrapper,
 } from '@styles/CommonStyles';
+import { formatAmountNumber } from '@utils/index';
 import { useEffect, useState } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, Controller } from 'react-hook-form';
 import styled from 'styled-components';
 
 // 지출 타입, 내용, 금액, 날짜
 const WriteExpense = () => {
-  const { register, watch } = useFormContext();
+  const { register, watch, control } = useFormContext();
   const [activeLabel, setActiveLabel] = useState('');
 
   const selectedRegisterType = watch('registerType');
@@ -23,6 +24,11 @@ const WriteExpense = () => {
   useEffect(() => {
     setActiveLabel(selectedRegisterType);
   }, [selectedRegisterType]);
+
+  const handleAmountChange = (value: string, onChange: (value: string) => void) => {
+    const formattedValue = formatAmountNumber(value);
+    onChange(formattedValue);
+  };
 
   return (
     <Container>
@@ -56,7 +62,19 @@ const WriteExpense = () => {
       <AmountContainer>
         <InputWrapper>
           <span className="title">금액</span>
-          <AmountInput placeholder="0" {...register('amount', { required: true })} />
+          <Controller
+            name="amount"
+            control={control}
+            defaultValue={''}
+            rules={{ required: true }}
+            render={({ field: { onChange, value, ...field } }) => (
+              <AmountInput
+                {...field}
+                value={value}
+                onChange={(event) => handleAmountChange(event.target.value, onChange)}
+                placeholder="0"
+              />
+            )}></Controller>
         </InputWrapper>
         <AmountText>원</AmountText>
       </AmountContainer>
@@ -148,16 +166,9 @@ const InputWrapper = styled.div`
   height: 70px;
 `;
 
-const AmountInput = styled.input.attrs({ type: 'number' })`
+const AmountInput = styled.input.attrs({ type: 'text' })`
   ${textArea}
-
-  // 화살표 숨기기
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-  appearance: textfield;
+  text-align: right;
 `;
 
 const AmountText = styled.div`

--- a/src/pages/expenseDetailView/components/EditSummary.tsx
+++ b/src/pages/expenseDetailView/components/EditSummary.tsx
@@ -10,10 +10,13 @@ import {
 } from '@styles/CommonStyles';
 import styled from 'styled-components';
 
-import { useFormContext } from 'react-hook-form';
-import { EmotionKey, EmotionKeys } from '@models/index';
+import { useFormContext, Controller } from 'react-hook-form';
+
 import Emotion from '@components/emotion';
 import MultiText from '@components/input/MultiText';
+
+import { EmotionKey, EmotionKeys } from '@models/index';
+import { formatAmountNumber } from '@utils/index';
 
 type EditSummaryProps = {
   isEditMode: boolean;
@@ -28,8 +31,14 @@ const EditSummary = ({
   selectEmotion,
   setSelectEmotion,
 }: EditSummaryProps) => {
-  const { register, setValue } = useFormContext();
+  const { register, setValue, control } = useFormContext();
   const satisfactionLabels = [1, 2, 3, 4, 5];
+
+  const handleAmountChange = (value: string, onChange: (value: string) => void) => {
+    const formattedValue = formatAmountNumber(value);
+    onChange(formattedValue);
+  };
+
   return (
     <>
       <div style={{ display: 'flex', width: '100%', gap: '10px' }}>
@@ -104,10 +113,20 @@ const EditSummary = ({
       <Content className="amount">
         <AmountWrapper>
           <span className="title">금액</span>
-          <AmountInput
-            placeholder="0"
-            disabled={!isEditMode}
-            {...register('amount', { required: true })}
+          <Controller
+            name="amount"
+            control={control}
+            defaultValue={''}
+            rules={{ required: true }}
+            render={({ field: { onChange, value, ...field } }) => (
+              <AmountInput
+                {...field}
+                value={value}
+                onChange={(event) => handleAmountChange(event.target.value, onChange)}
+                placeholder="0"
+                disabled={!isEditMode}
+              />
+            )}
           />
         </AmountWrapper>
         <AmountText>원</AmountText>
@@ -222,16 +241,9 @@ const AmountWrapper = styled.div`
   height: 70px;
 `;
 
-const AmountInput = styled.input.attrs({ type: 'number' })`
+const AmountInput = styled.input.attrs({ type: 'text' })`
   ${textArea}
-  background-color: transparent;
-  // 화살표 숨기기
-  &::-webkit-outer-spin-button,
-  &::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-  appearance: textfield;
+  text-align: right;
 `;
 
 const AmountText = styled.div`

--- a/src/pages/expenseListView/ExpenseListViewPage.tsx
+++ b/src/pages/expenseListView/ExpenseListViewPage.tsx
@@ -57,7 +57,7 @@ const NavigationLayout = ({ children }: NavLayoutProps) => {
           <TopNavigation.TopBar
             centerContent={
               <TopNavigation.TopBar.CenterTitle style={{ color: '#ffffff' }}>
-                소비 내역 조회
+                내역 조회
               </TopNavigation.TopBar.CenterTitle>
             }
             rightContent={

--- a/src/pages/expenseListView/ExpenseListViewPage.tsx
+++ b/src/pages/expenseListView/ExpenseListViewPage.tsx
@@ -193,7 +193,7 @@ const ExpenseListViewPage = () => {
             <span className="filter-btn" onClick={toggleModal}>
               <FilterBtn />
             </span>
-            <SelectList>
+            <SelectList onClick={toggleModal}>
               <Select>{`${formatYMD(condition.from)}-${formatYMD(condition.to)}`}</Select>
               {condition.registerType.length > 0 && (
                 <Select>
@@ -412,7 +412,7 @@ const Arrow = styled(PrevBtn)<{ deg: string }>`
 
   &:hover {
     color: #9f9f9f;
-    transform: rotate(90deg);
+    transform: rotate(${(props) => props.deg});
     stroke-width: 4;
   }
 `;

--- a/src/pages/expenseListView/components/SelectEmotion.tsx
+++ b/src/pages/expenseListView/components/SelectEmotion.tsx
@@ -1,12 +1,29 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { EmotionKey, EmotionKeys } from '@models/index';
 import Emotion from '@components/emotion';
 import { useFormContext } from 'react-hook-form';
+import { flexBetween, flexCenter } from '@styles/CommonStyles';
+import { getEmotionText } from '@models/emotion';
+import { PrevBtn } from '@components/button';
+import { useState } from 'react';
 
 const SelectEmotion = () => {
   const { setValue, watch, getValues } = useFormContext();
   const selectedOptions = watch('emotion'); // 감정 문자열 배열
+
+  const [isFold, setIsFold] = useState<boolean>(false);
+  const handleFold = () => {
+    setIsFold((prev) => !prev);
+  };
+
+  const getChekedItemMessage = () => {
+    const currentValues: EmotionKey[] = getValues('emotion');
+
+    if (currentValues.length === 0) return `0건`;
+    if (currentValues.length === 1) return `${getEmotionText(currentValues[0])}`;
+    return `${getEmotionText(currentValues[0])} 외 ${currentValues.length - 1}건`;
+  };
 
   const handleCheckboxChange = (selectEmotion: EmotionKey) => {
     const value: EmotionKey = selectEmotion;
@@ -29,25 +46,31 @@ const SelectEmotion = () => {
 
   return (
     <Container>
-      <div style={{ display: 'flex' }}>
-        <span className="sub-title">감정 선택</span>
-      </div>
-      <EmotionContainer>
-        {EmotionKeys.map((x) => (
-          <div key={x} style={{ width: '56px', height: '70px' }}>
-            <Emotion
-              emotionKey={x}
-              isSelect={selectedOptions.includes(x)}
-              onClick={() => {
-                handleCheckboxChange(x);
-              }}
-              iconSize={45}
-              textSize={12}
-              selectSize={24}
-            />
-          </div>
-        ))}
-      </EmotionContainer>
+      <Title style={{ display: 'flex' }}>
+        <span className="sub-title">
+          감정 다수 선택
+          <Arrow onClick={handleFold} deg={`${isFold ? '90deg' : '270deg'}`} />
+        </span>
+        <span className="select">{getChekedItemMessage()}</span>
+      </Title>
+      {isFold && (
+        <EmotionContainer>
+          {EmotionKeys.map((x) => (
+            <EmotionWrapper key={x}>
+              <Emotion
+                emotionKey={x}
+                isSelect={selectedOptions.includes(x)}
+                onClick={() => {
+                  handleCheckboxChange(x);
+                }}
+                iconSize={50}
+                textSize={12}
+                selectSize={18}
+              />
+            </EmotionWrapper>
+          ))}
+        </EmotionContainer>
+      )}
     </Container>
   );
 };
@@ -72,4 +95,37 @@ const EmotionContainer = styled.div`
   width: 100%;
 
   gap: 30px;
+`;
+
+const EmotionWrapper = styled.div`
+  ${flexCenter}
+  width: 56px;
+  height: 70px;
+`;
+
+const Title = styled.div`
+  ${flexBetween}
+
+  & > span.select {
+    font-size: 14px;
+    color: #767676;
+  }
+`;
+
+const arrowStyle = css`
+  width: 10px;
+  height: 10px;
+  color: #9f9f9f;
+  stroke-width: 4;
+`;
+
+const Arrow = styled(PrevBtn)<{ deg: string }>`
+  ${arrowStyle}
+  transform: rotate(${(props) => props.deg});
+  margin-left: 7px;
+  &:hover {
+    color: #9f9f9f;
+    transform: rotate(${(props) => props.deg});
+    stroke-width: 4;
+  }
 `;

--- a/src/pages/main/components/Budget.tsx
+++ b/src/pages/main/components/Budget.tsx
@@ -16,7 +16,7 @@ const Budget = ({ monthBudget, monthSpend, monthSave }: BudgetProps) => {
   const percent: string = `${Math.ceil((monthSpend / monthBudget) * 100)}%`;
   const remain: number = Math.floor(monthBudget - monthSpend);
   const recommend: number = Math.floor(monthBudget / 30);
-
+  const isBudgetZero = monthBudget === 0;
   return (
     <>
       <Remain>
@@ -36,11 +36,15 @@ const Budget = ({ monthBudget, monthSpend, monthSave }: BudgetProps) => {
         </GoSetting>
       </Remain>
       <Bar>
-        <BarDetail percent={percent}>
-          <span className="bar-mark"></span>
-          <span className="bar-percent"></span>
-          <span className="bar-text">{percent}</span>
-        </BarDetail>
+        {isBudgetZero ? (
+          '설정에서 예산을 입력해주세요'
+        ) : (
+          <BarDetail percent={percent}>
+            <span className="bar-mark"></span>
+            <span className="bar-percent"></span>
+            <span className="bar-text">{percent}</span>
+          </BarDetail>
+        )}
       </Bar>
       <Info>
         <InfoItem>
@@ -121,6 +125,9 @@ const Bar = styled.div`
   width: 100%;
   height: 20%;
   padding: 5px;
+
+  font-size: 14px;
+  color: #333331;
 `;
 
 // @keyframes를 사용하여 애니메이션 정의

--- a/src/pages/main/components/Calendar.tsx
+++ b/src/pages/main/components/Calendar.tsx
@@ -147,7 +147,7 @@ const Calendar = ({ currentDate, setCurrentDate, data }: CalendarProps) => {
               )}
               {daySave > 0 && (
                 <Detail>
-                  절약:<span>{`${addCommasToNumber(daySave)}원`}</span>
+                  절약:<span>{`+${addCommasToNumber(daySave)}원`}</span>
                 </Detail>
               )}
             </ExpenseDetail>

--- a/src/pages/main/components/DayExpenseTop2.tsx
+++ b/src/pages/main/components/DayExpenseTop2.tsx
@@ -72,10 +72,10 @@ const DayExpenseListTop2 = ({ data, currentDate }: DayExpenseListTop2Props) => {
                 <span className="sub">{`총 ${data.length}건`}</span>
               </Title>
               <ListWrapper>
-                {data.map((x) => {
+                {data.map((summary) => {
                   return (
-                    <ExpenseBox key={x.articleId}>
-                      <ExpenseSummary {...x} />
+                    <ExpenseBox key={summary.articleId}>
+                      <ExpenseSummary {...summary} />
                     </ExpenseBox>
                   );
                 })}

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -89,7 +89,7 @@ const GlobalStyles = createGlobalStyle`
     width: 100vw;
     height: 100vh;
     overflow: hidden; // 모바일 화면에서 세로, 가로 스크롤 방지
-    
+    font-family: 'SUIT';
   }
 
   #root {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,10 +8,39 @@ import {
   eachDayOfInterval,
 } from 'date-fns';
 
-// 숫자에 3자리씩 ',' 찍어주는 함수
-export const addCommasToNumber = (number: number): string => {
+// #,##0 형식 formatter (숫자에 3자리씩 ',' 찍어주는 함수)
+export const addCommasToNumber = (number: number | string): string => {
   if (number == undefined || number == null) return '0';
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};
+
+// #,##0 포맷된 string 또는 숫자를 다시 #,##0 으로 포맷
+export const formatAmountNumber = (
+  value: string,
+  hasLimit: boolean = false,
+  limit: number = 100000000,
+): string => {
+  /* case )
+   * 1. input의 handleChanged에서 #,##0 포맷된 string을 전달받음
+   * 2. 서버에서 넘어온 데이터는 숫자 형태의 string으로 넘어옴.
+   */
+  // 숫자만 포함된 값으로 변환
+  let cleanedValue = value.replace(/[^0-9]/g, '');
+
+  // 0으로 시작하지 않도록 제한
+  if (cleanedValue.startsWith('0')) {
+    cleanedValue = cleanedValue.replace(/^0+/, ''); // 0으로 시작할 경우 0->빈값으로 치환
+  }
+
+  // limit을 가지고 있다면, limit을 넘지 못하도록 제한 (제한 숫자로 바꿈)
+  if (hasLimit && cleanedValue.length > 0) {
+    const numericValue = parseInt(cleanedValue, 10); // 문자열을 정수로 변환
+    if (numericValue > limit) {
+      cleanedValue = limit.toString(); // 제한 값을 문자열로 변환
+    }
+  }
+
+  return addCommasToNumber(cleanedValue);
 };
 
 // Date 객체 -> yyyyMMdd String
@@ -79,7 +108,7 @@ export const getDateObjArray = (date: Date) => {
 export const getSpendSumamryText = (
   spendDate: string,
   content: string,
-  amount: number,
+  amount: string,
   regiesterType: string,
 ) => {
   return `${formatYMD(formatFromServer(spendDate))}, "${content}"에 ${addCommasToNumber(amount)}원 ${regiesterType === 'SPEND' ? '지출' : '절약'}`;


### PR DESCRIPTION
## 🧰 변경 타입

- [x] 🤹 FEAT : 기능 추가
- [ ] 🔧 FIX : 버그 수정
- [ ] ♻️ 리팩토링 (no functional changes, no api changes)
- [ ] 🎨 DESIGN : 디자인 작업
- [ ] 🚚 BUILD : 빌드 관련 변경
- [ ] 🤖 STYLE : 코드 스타일 혹은 포맷 관련 변경
- [ ] 💬 COMMENT : 주석 작성
- [ ] 📄 DOCS : 문서 작업
- [ ] 🗑️ DELETE : 파일 삭제
- [ ] 🩹 CHORE : 그 외 자잘한 수정

## ✒️ 변경 상세 내용

### 금액 입력칸에 `#,##0` 포맷 적용
<img width="281" alt="image" src="https://github.com/SpinLog/frontend/assets/137787915/a2e43fec-04f8-4eac-8be1-0bdc839fc77d">

- `react-hook-form`의 `Controller` 사용
- 기존 number type input 들 text로 변경하며 `#,##0` 포맷 적용
- 우측 정렬 추가
- 환경설정>예산의 경우, 1억 이상의 숫자 입력 시, 최대숫자인 1억으로 변환
  - 금액과 관련된 데이터다보니, 정확한 금액 입력이 중요하다고 생각하여 최대 제한값으로 변경하는 방식 선택

=> `#,##0` 로 포맷되는 text input을 hook이나 공용 컴포넌트로 빼려다가 실패함

### 자잘한 수정
- 상단 monthNav 다음줄로 넘어가져서 너비 늘림
- 필터에서 감정 아이콘 정렬 깨지는 것 수정, 선택한 감정 이름과 개수 뜨도록 기능 개선
- 필터 감정 div 접히고 펼쳐지게 개선
- `부끄러움/민망` -> `민망/수치` 텍스트 변경
- 상단 바 화면명 `소비내역조회` -> `내역 조회` 변경
- 필터 라벨 눌러도 필터 뜨게 변경 (그냥 부모에다가 이벤트 달아놓음)
- 메인 화면에서 예산이 0일 경우 처리 (디자인나오면 추후 다시 수정 필요)
- 메인화면 달력 라벨에 절약일 경우 `+` 기호 추가